### PR TITLE
tree-wide: fix references to the terraform-providers organization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ NOTES:
 
 IMPROVEMENTS
 
-* Trace logging added for JSON output ([#36](https://github.com/terraform-providers/terraform-provider-external/issues/36))
+* Trace logging added for JSON output ([#36](https://github.com/hashicorp/terraform-provider-external/issues/36))
 
 ## 1.1.2 (April 30, 2019)
 
@@ -23,7 +23,7 @@ IMPROVEMENTS
 ENHANCEMENTS:
 
 * The provider is now compatible with Terraform v0.12, while retaining compatibility with prior versions.
-* `external` data source now accepts `working_dir` argument to set the working directory for the child process. ([#12](https://github.com/terraform-providers/terraform-provider-external/issues/12))
+* `external` data source now accepts `working_dir` argument to set the working directory for the child process. ([#12](https://github.com/hashicorp/terraform-provider-external/issues/12))
 
 ## 1.0.0 (September 14, 2017)
 

--- a/README.md
+++ b/README.md
@@ -21,17 +21,17 @@ Requirements
 Building The Provider
 ---------------------
 
-Clone repository to: `$GOPATH/src/github.com/terraform-providers/terraform-provider-external`
+Clone repository to: `$GOPATH/src/github.com/hashicorp/terraform-provider-external`
 
 ```sh
-$ mkdir -p $GOPATH/src/github.com/terraform-providers; cd $GOPATH/src/github.com/terraform-providers
-$ git clone git@github.com:terraform-providers/terraform-provider-external
+$ mkdir -p $GOPATH/src/github.com/hashicorp; cd $GOPATH/src/github.com/hashicorp
+$ git clone git@github.com:hashicorp/terraform-provider-external
 ```
 
 Enter the provider directory and build the provider
 
 ```sh
-$ cd $GOPATH/src/github.com/terraform-providers/terraform-provider-external
+$ cd $GOPATH/src/github.com/hashicorp/terraform-provider-external
 $ make build
 ```
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/terraform-providers/terraform-provider-external
+module github.com/hashicorp/terraform-provider-external
 
 require (
 	github.com/hashicorp/hcl v1.0.0 // indirect

--- a/main.go
+++ b/main.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"github.com/hashicorp/terraform-plugin-sdk/plugin"
-	"github.com/terraform-providers/terraform-provider-external/external"
+	"github.com/hashicorp/terraform-provider-external/external"
 )
 
 func main() {

--- a/scripts/changelog-links.sh
+++ b/scripts/changelog-links.sh
@@ -24,7 +24,7 @@ else
   SED="sed -i.bak -r -e"
 fi
 
-PROVIDER_URL="https:\/\/github.com\/terraform-providers\/terraform-provider-external\/issues"
+PROVIDER_URL="https:\/\/github.com\/hashicorp\/terraform-provider-external\/issues"
 
 $SED "s/GH-([0-9]+)/\[#\1\]\($PROVIDER_URL\/\1\)/g" -e 's/\[\[#(.+)([0-9])\)]$/(\[#\1\2))/g' CHANGELOG.md
 


### PR DESCRIPTION
`terraform-provider-external` has been moved to the `hashicorp`
organization.