### PR TITLE
In Debugging mode, print the JSON from external data source as a string

### DIFF
--- a/external/data_source.go
+++ b/external/data_source.go
@@ -79,7 +79,7 @@ func dataSourceRead(d *schema.ResourceData, meta interface{}) error {
 	cmd.Stdin = bytes.NewReader(queryJson)
 
 	resultJson, err := cmd.Output()
-	log.Printf("[TRACE] JSON output: %+v\n", resultJson)
+	log.Printf("[TRACE] JSON output: %+v\n", string(resultJson))
 	if err != nil {
 		if exitErr, ok := err.(*exec.ExitError); ok {
 			if exitErr.Stderr != nil && len(exitErr.Stderr) > 0 {


### PR DESCRIPTION
# Description

In Debugging mode, print the JSON from external data source as a string.

Currently it prints it as a bytes array.

```
2020-09-29T21:46:22.145-0700 [DEBUG] plugin: plugin exited
2020-09-29T21:46:23.830-0700 [DEBUG] plugin.terraform-provider-external: 2020/09/29 21:46:23 [TRACE] JSON output: [333 45 75 32 34 83 ... 24 45 66]
2020/09/29 21:46:23 [ERROR] module.my-module: eval: *terraform.EvalReadData, err: command "bash" produ...
```

This makes debugging the issue very hard. It's easier to see it as a string and figure out the issue with the JSON output.