### PR TITLE
Update Terraform CLI versions to latest in test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,9 +51,10 @@ jobs:
       fail-fast: false
       matrix:
         terraform:
-          - '0.12.30'
-          - '0.13.6'
-          - '0.14.5'
+          - '0.12.31'
+          - '0.13.7'
+          - '0.14.11'
+          - '0.15.1'
     steps:
 
     - name: Set up Go


### PR DESCRIPTION
TF 0.14 updated from 0.14.5 to 0.14.7