### PR TITLE
data-source/external: Switch to tflog, add trace log for program being executed

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,5 +4,6 @@ go 1.15
 
 require (
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320
+	github.com/hashicorp/terraform-plugin-log v0.2.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.10.1
 )

--- a/internal/provider/data_source.go
+++ b/internal/provider/data_source.go
@@ -5,11 +5,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"log"
 	"os/exec"
 	"runtime"
 
 	"github.com/hashicorp/go-cty/cty"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -133,8 +133,12 @@ The program must also be executable according to the platform where Terraform is
 	cmd.Dir = workingDir
 	cmd.Stdin = bytes.NewReader(queryJson)
 
+	tflog.Trace(ctx, "Executing external program", "program", cmd.String())
+
 	resultJson, err := cmd.Output()
-	log.Printf("[TRACE] JSON output: %+v\n", string(resultJson))
+
+	tflog.Trace(ctx, "Executed external program", "program", cmd.String(), "output", string(resultJson))
+
 	if err != nil {
 		if exitErr, ok := err.(*exec.ExitError); ok {
 			if exitErr.Stderr != nil && len(exitErr.Stderr) > 0 {


### PR DESCRIPTION
Closes #22

Provider will now produce trace logging such as:

```
2021-12-20T09:45:21.305-0500 [TRACE] sdk.proto: Received request: tf_data_source_type=external tf_proto_version=5 tf_provider_addr=registry.terraform.io/hashicorp/external tf_req_id=f7754152-04ab-826b-3dec-c68af595576a tf_rpc=ReadDataSource
2021-12-20T09:45:21.305-0500 [TRACE] sdk.proto: Calling downstream: tf_data_source_type=external tf_proto_version=5 tf_provider_addr=registry.terraform.io/hashicorp/external tf_req_id=f7754152-04ab-826b-3dec-c68af595576a tf_rpc=ReadDataSource
2021-12-20T09:45:21.305-0500 [TRACE] external: Executing external program: tf_data_source_type=external tf_provider_addr=registry.terraform.io/hashicorp/external tf_req_id=f7754152-04ab-826b-3dec-c68af595576a tf_rpc=ReadDataSource program=/Users/bflad/go/bin/tf-acc-external-data-source
2021-12-20T09:45:21.375-0500 [TRACE] external: Executed external program: tf_data_source_type=external tf_provider_addr=registry.terraform.io/hashicorp/external tf_req_id=f7754152-04ab-826b-3dec-c68af595576a tf_rpc=ReadDataSource program=/Users/bflad/go/bin/tf-acc-external-data-source output=""
2021-12-20T09:45:21.375-0500 [TRACE] sdk.proto: Called downstream: tf_data_source_type=external tf_proto_version=5 tf_provider_addr=registry.terraform.io/hashicorp/external tf_req_id=f7754152-04ab-826b-3dec-c68af595576a tf_rpc=ReadDataSource
2021-12-20T09:45:21.375-0500 [TRACE] sdk.proto: Served request: tf_data_source_type=external tf_proto_version=5 tf_provider_addr=registry.terraform.io/hashicorp/external tf_req_id=f7754152-04ab-826b-3dec-c68af595576a tf_rpc=ReadDataSource
```