### PR TITLE
.github/workflows: Automatically test latest Terraform CLI patch version, add 1.1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -69,6 +69,8 @@ jobs:
       with:
         terraform_version: ${{ matrix.terraform }}
         terraform_wrapper: false
+    - run: go mod download
+    - run: terraform version
     - name: TF acceptance tests
       timeout-minutes: 10
       env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,11 +50,12 @@ jobs:
       fail-fast: false
       matrix:
         terraform:
-          - '0.12.31'
-          - '0.13.7'
-          - '0.14.11'
-          - '0.15.5'
-          - '1.0.1'
+          - '0.12.*'
+          - '0.13.*'
+          - '0.14.*'
+          - '0.15.*'
+          - '1.0.*'
+          - '1.1.*'
     steps:
     - uses: actions/checkout@v2.3.4
     - id: go-version
@@ -64,11 +65,12 @@ jobs:
       with:
         go-version: ${{ steps.go-version.outputs.version }}
       id: go
-
+    - uses: hashicorp/setup-terraform@v1
+      with:
+        terraform_version: ${{ matrix.terraform }}
+        terraform_wrapper: false
     - name: TF acceptance tests
       timeout-minutes: 10
       env:
         TF_ACC: "1"
-        TF_ACC_TERRAFORM_VERSION: ${{ matrix.terraform }}
-      run: |
-        go test -v -cover ./internal/provider/
+      run: go test -v -cover ./internal/provider/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -69,8 +69,9 @@ jobs:
       with:
         terraform_version: ${{ matrix.terraform }}
         terraform_wrapper: false
-    - run: go mod download
+    # See also: https://github.com/hashicorp/setup-terraform/issues/143
     - run: terraform version
+    - run: go mod download
     - name: TF acceptance tests
       timeout-minutes: 10
       env:


### PR DESCRIPTION
Reference: https://github.com/hashicorp/terraform-provider-scaffolding-framework/blob/main/.github/workflows/test.yml

The `TF_ACC_TERRAFORM_VERSION` environment variable handling in the acceptance testing framework does not support this functionality, so switch to the hashicorp/setup-terraform action instead.