### PR TITLE
Add Terraform protocol version headers to release process

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -42,7 +42,10 @@ checksum:
   name_template: '{{ .ProjectName }}_{{ .Version }}_SHA256SUMS'
 publishers:
   - checksum: true
-    cmd: hc-releases upload-file {{ abs .ArtifactPath }}
+    # Terraform CLI 0.10 - 0.11 perform discovery via HTTP headers on releases.hashicorp.com
+    # For providers which have existed since those CLI versions, exclude
+    # discovery by setting the protocol version headers to 5.
+    cmd: hc-releases upload-file {{ abs .ArtifactPath }} -header=x-terraform-protocol-version=5 -header=x-terraform-protocol-versions=5.0
     env:
       - AWS_ACCESS_KEY_ID={{ .Env.AWS_ACCESS_KEY_ID }}
       - AWS_SECRET_ACCESS_KEY={{ .Env.AWS_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
Reference: https://github.com/hashicorp/terraform-provider-external/issues/100 (going to keep open until Terraform Registry database is updated to fix 0.12)
Reference: https://github.com/goreleaser/goreleaser/issues/2768

Since this is widely used provider, prevent new version discovery on Terraform CLI 0.10 and 0.11. Relatedly, this will ensure future releases are compatible with Terraform CLI 0.12, since this information is used during Terraform Registry ingest, pending a feature request to `goreleaser` that will allow publishing the extra manifest file.