### PR TITLE
data-source/external: Use ReadWithoutTimeout instead of ReadContext

### DIFF
--- a/internal/provider/data_source.go
+++ b/internal/provider/data_source.go
@@ -31,7 +31,7 @@ func dataSource() *schema.Resource {
 			"or external programs beyond standard shell utilities, so it is not recommended to use this data source " +
 			"within configurations that are applied within Terraform Enterprise.",
 
-		ReadContext: dataSourceRead,
+		ReadWithoutTimeout: dataSourceRead,
 
 		Schema: map[string]*schema.Schema{
 			"program": {


### PR DESCRIPTION
Closes #164

Proposed CHANGELOG entry:

```
data-source/external: Prevented unexpected error after 20 minutes of program execution
```

The additional acceptance test is placed behind an environment variable flag since it is extremely long running compared to other testing.

Without the flag:

```console
$ TF_ACC=1 go test -count=1 -run='TestDataSource_20MinuteTimeout' -v ./internal/provider
=== RUN   TestDataSource_20MinuteTimeout
    data_source_test.go:197: Skipping this test since the TF_ACC_EXTERNAL_TIMEOUT_TEST environment variable is not set to any value. This test requires 20 minutes to run, so it is disabled by default.
--- SKIP: TestDataSource_20MinuteTimeout (0.00s)
PASS
ok      github.com/terraform-providers/terraform-provider-external/internal/provider    0.982s
```

With the flag:

```console
$ TF_ACC=1 TF_ACC_EXTERNAL_TIMEOUT_TEST=1 go test -count=1 -run='TestDataSource_20MinuteTimeout' -timeout=30m -v ./internal/provider
=== RUN   TestDataSource_20MinuteTimeout
--- PASS: TestDataSource_20MinuteTimeout (1205.18s)
PASS
ok      github.com/terraform-providers/terraform-provider-external/internal/provider    1205.465s
```