### PR TITLE
Rename `IMPROVEMENTS` Changie label to `ENCHANCEMENTS`

### DIFF
--- a/.changie.yaml
+++ b/.changie.yaml
@@ -14,7 +14,7 @@ kinds:
   - label: BREAKING CHANGES
   - label: NOTES
   - label: FEATURES
-  - label: IMPROVEMENTS
+  - label: ENHANCEMENTS
   - label: BUG FIXES
 newlines:
   afterKind: 1


### PR DESCRIPTION
Renames the Changie category label to `ENHANCEMENTS` which is more widely used across our repos