### PR TITLE
Remove filter for empty and null query values

### DIFF
--- a/.changes/unreleased/BUG FIXES-20230306-143852.yaml
+++ b/.changes/unreleased/BUG FIXES-20230306-143852.yaml
@@ -1,0 +1,6 @@
+kind: BUG FIXES
+body: 'data-source/external: Remove query validation to allow null and empty string
+  values to be passed to the external program'
+time: 2023-03-06T14:38:52.356522-05:00
+custom:
+  Issue: "193"

--- a/internal/provider/data_source.go
+++ b/internal/provider/data_source.go
@@ -133,10 +133,6 @@ func (n *externalDataSource) Read(ctx context.Context, req datasource.ReadReques
 
 	filteredQuery := make(map[string]string)
 	for key, value := range query {
-		if value.IsNull() || value.ValueString() == "" {
-			continue
-		}
-
 		filteredQuery[key] = value.ValueString()
 	}
 

--- a/internal/provider/data_source_test.go
+++ b/internal/provider/data_source_test.go
@@ -190,7 +190,7 @@ func TestDataSource_Program_EmptyStringAndNullValues(t *testing.T) {
 	})
 }
 
-func TestDataSource_Query_NullValue(t *testing.T) {
+func TestDataSource_Query_NullAndEmptyValue(t *testing.T) {
 	programPath, err := buildDataSourceTestProgram()
 	if err != nil {
 		t.Fatal(err)
@@ -206,12 +206,14 @@ func TestDataSource_Query_NullValue(t *testing.T) {
 						program = [%[1]q]
 				
 						query = {
-							value = null
+							value = null,
+							value2 = ""
 						}
 					}
 				`, programPath),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("data.external.test", "result.query_value", ""),
+					resource.TestCheckResourceAttr("data.external.test", "result.value", ""),
+					resource.TestCheckResourceAttr("data.external.test", "result.value2", ""),
 				),
 			},
 		},

--- a/internal/provider/test-programs/tf-acc-external-data-source/main.go
+++ b/internal/provider/test-programs/tf-acc-external-data-source/main.go
@@ -40,6 +40,10 @@ func main() {
 		result["argument"] = os.Args[1]
 	}
 
+	for queryKey, queryValue := range query {
+		result[queryKey] = queryValue
+	}
+
 	resultBytes, err := json.Marshal(result)
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
Fixes: #193 

What?

- Removes a filter for empty and null query values that removed these values from the query before the query is encoded into JSON. This mirrors the behavior of the [SDKv2 version](https://github.com/hashicorp/terraform-provider-external/blob/v2.2.3/internal/provider/data_source.go#L109) of the provider.
- Add additional output in `main.go` test program that is being used in Acceptance testing to correctly test this behavior.