### PR TITLE
data-source/external: Omit query attribute map elements with null values

### DIFF
--- a/.changes/unreleased/BUG FIXES-20230410-130443.yaml
+++ b/.changes/unreleased/BUG FIXES-20230410-130443.yaml
@@ -1,0 +1,6 @@
+kind: BUG FIXES
+body: 'data-source/external: Prevent regression since v2.3.1 where null `query` element
+  values would be sent to the program as an empty string'
+time: 2023-04-10T13:04:43.615508-04:00
+custom:
+  Issue: "208"

--- a/internal/provider/data_source.go
+++ b/internal/provider/data_source.go
@@ -134,6 +134,17 @@ func (n *externalDataSource) Read(ctx context.Context, req datasource.ReadReques
 
 	filteredQuery := make(map[string]string)
 	for key, value := range query {
+		// Preserve v2.2.3 and earlier behavior of filtering whole map elements
+		// with null values.
+		// Reference: https://github.com/hashicorp/terraform-provider-external/issues/208
+		//
+		// The external program protocol could be updated to support null values
+		// as a breaking change by marshaling map[string]*string to JSON.
+		// Reference: https://github.com/hashicorp/terraform-provider-external/issues/209
+		if value.IsNull() {
+			continue
+		}
+
 		filteredQuery[key] = value.ValueString()
 	}
 

--- a/internal/provider/test-programs/tf-acc-external-data-source/main.go
+++ b/internal/provider/test-programs/tf-acc-external-data-source/main.go
@@ -20,20 +20,23 @@ func main() {
 		panic(err)
 	}
 
-	var query map[string]string
+	var query map[string]*string
 	err = json.Unmarshal(queryBytes, &query)
 	if err != nil {
 		panic(err)
 	}
 
-	if query["fail"] != "" {
+	if _, ok := query["fail"]; ok {
 		fmt.Fprintf(os.Stderr, "I was asked to fail\n")
 		os.Exit(1)
 	}
 
 	var result = map[string]string{
-		"result":      "yes",
-		"query_value": query["value"],
+		"result": "yes",
+	}
+
+	if queryValue, ok := query["value"]; ok && queryValue != nil {
+		result["query_value"] = *queryValue
 	}
 
 	if len(os.Args) >= 2 {
@@ -41,7 +44,9 @@ func main() {
 	}
 
 	for queryKey, queryValue := range query {
-		result[queryKey] = queryValue
+		if queryValue != nil {
+			result[queryKey] = *queryValue
+		}
 	}
 
 	resultBytes, err := json.Marshal(result)


### PR DESCRIPTION
Reference: https://github.com/hashicorp/terraform-provider-external/pull/194
Closes #208

The migration to terraform-plugin-framework exposes map values wholly and v2.3.0 handled that transition properly. However, v2.3.1 introduced a subtle change where `query` attribute map elements with null values are now sent with an empty string value, rather than being omitted like previously. Since certain receiving `program` may be dependent on the nuance of `query` values, null element values should continue to omit the element entirely to prevent the introduction of a breaking change.

Previously before logic update:

```
=== RUN   TestDataSource_Query_NullElementValue
    data_source_test.go:367: Step 1/1 error: Error running pre-apply refresh: exit status 1

        Error: External Program Execution Failed

          with data.external.test,
          on terraform_plugin_test.tf line 3, in data "external" "test":
           3:                             program = ["/Users/bflad/go/bin/tf-acc-external-data-source"]

        The data source received an unexpected error while attempting to execute the
        program.

        Program: /Users/bflad/go/bin/tf-acc-external-data-source
        Error Message: I was asked to fail

        State: exit status 1
--- FAIL: TestDataSource_Query_NullElementValue (0.26s)
```