### PR TITLE
Remove Go version upgrade changelog for `v2.3.2` release

### DIFF
--- a/.changes/unreleased/NOTES-20230303-143616.yaml
+++ b/.changes/unreleased/NOTES-20230303-143616.yaml
@@ -1,6 +1,0 @@
-kind: NOTES
-body: This Go module has been updated to Go 1.19 per the [Go support policy](https://golang.org/doc/devel/release.html#policy).
-  Any consumers building on earlier Go versions may experience errors.
-time: 2023-03-03T14:36:16.25267Z
-custom:
-  Issue: "192"


### PR DESCRIPTION
Despite the branch name, this PR removes the Go version changelog preparing for the `v2.3.2` release (which does have one bug fix)