### PR TITLE
Permit use of shell aliases

### DIFF
--- a/internal/provider/data_source.go
+++ b/internal/provider/data_source.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
 	"os/exec"
 	"runtime"
 	"strings"
@@ -178,6 +179,25 @@ func (n *externalDataSource) Read(ctx context.Context, req datasource.ReadReques
 		err = nil
 	}
 
+	executableString := filteredProgram
+
+	if runtime.GOOS != "windows" && errors.Is(err, exec.ErrNotFound) {
+		// Add other shells here as need arises, the only requirement being it must provide "standard"
+		// behavior for the -i and -c options
+		shells := []string{"bash", "fish", "zsh", "ksh", "ash", "sh", "dash"}
+
+		sh := os.Getenv("SHELL")
+		for _, s := range shells {
+			if strings.HasSuffix(sh, "/"+s) {
+				executableString = []string{sh, "-i", "-c"}
+				args := strings.Join(filteredProgram, " ")
+				executableString = append(executableString, args)
+				err = nil
+				break
+			}
+		}
+	}
+
 	if err != nil {
 		resp.Diagnostics.AddAttributeError(
 			path.Root("program"),
@@ -202,7 +222,7 @@ The program must also be executable according to the platform where Terraform is
 
 	workingDir := config.WorkingDir.ValueString()
 
-	cmd := exec.CommandContext(ctx, filteredProgram[0], filteredProgram[1:]...)
+	cmd := exec.CommandContext(ctx, executableString[0], executableString[1:]...)
 
 	// This is a workaround to preserve pre-existing behaviour prior to the upgrade to Go 1.19.
 	// Reference: https://github.com/hashicorp/terraform-provider-external/pull/192


### PR DESCRIPTION
Today, the provider does not handle programs that are defined as shell alias.

This is primarily due to the [go exec LookPath](https://pkg.go.dev/os/exec#LookPath) limitation, it searches from PATH environment variable but does not provide any shell implementations.

This is a proposition to execute the program from a shell when the program is not located in PATH.
For now the following shells are supported :
- bash
- fish
- zsh
- ksh
- ash
- sh
- dash

I took as example an implementation from https://github.com/mmmorris1975/aws-runas