### PR TITLE
Bump go patch version to 1.21.13

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/terraform-providers/terraform-provider-external
 
 go 1.21
 
-toolchain go1.21.6
+toolchain go1.21.13
 
 require (
 	github.com/hashicorp/terraform-plugin-framework v1.11.0

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -2,6 +2,8 @@ module tools
 
 go 1.21
 
+toolchain go1.21.13
+
 require (
 	github.com/hashicorp/copywrite v0.19.0
 	github.com/hashicorp/terraform-plugin-docs v0.19.4


### PR DESCRIPTION
Due to CVE-2024-24790 the minimum required go version has to be increased.